### PR TITLE
Relocate helper script files to 'contrib/' directory.

### DIFF
--- a/contrib/run
+++ b/contrib/run
@@ -1,2 +1,5 @@
+# -*- mode: sh -*-
+#!/bin/sh
+
 cd ../example-implementation
 rackup -p 4567

--- a/contrib/update
+++ b/contrib/update
@@ -1,3 +1,6 @@
+# -*- mode: sh -*-
+#!/bin/sh
+
 cd ../example-implementation
 git pull
 cd ../frecon


### PR DESCRIPTION
Per the comments on d166529be0ecad24f5f85867b687026362f053cf, I've decided to request to move these scripts to a 'contrib/' directory.  The only disadvantage that I can see and that applies to people who use these scripts is that they have to use `contrib/run` and `contrib/update` instead of just `./run` and `./update`.  However, this is more conventional; these scripts have no connection to FReCon, besides being an amenity for contributors.

I plan to open more pull requests like this regarding changes to these scripts so that I can get feedback before they get merged.  I don't want to make working on this project start sucking for people, but at the same time these scripts need to be more dynamic.
