### PR TITLE
Delete the convenience scripts.

### DIFF
--- a/contrib/run
+++ b/contrib/run
@@ -1,5 +1,0 @@
-# -*- mode: sh -*-
-#!/bin/sh
-
-cd ../example-implementation
-rackup -p 4567

--- a/contrib/update
+++ b/contrib/update
@@ -1,9 +1,0 @@
-# -*- mode: sh -*-
-#!/bin/sh
-
-cd ../example-implementation
-git pull
-cd ../frecon
-git pull
-gem build frecon.gemspec
-gem install --local frecon-0.0.0.gem


### PR DESCRIPTION
While the idea was definitely valid, some problems with non-general-purposefulness were encountered.  Using ".." as a reference is sketchy and doesn't always work.  In addition, these scripts were pertinent to the workflow of FReCon developers, not the actual FReCon codebase itself.

I think it would be nice to write a script to perform the setup of FReCon.  Multiple-line installs are painful, and having to read a list of instructions is also inefficient.  It'd be great if we could get something like the RVM installation script deployed somewhere to clone and set up FReCon and the Example Implementation quickly.
