### PR TITLE
Expand $LOAD_PATH using mapping, and be consistent in evaluation.

### DIFF
--- a/bin/frecon
+++ b/bin/frecon
@@ -11,7 +11,7 @@
 
 # Include rel-path ../lib/ in the $LOAD_PATH if it's not there already.
 lib_directory = File.expand_path(File.join(File.dirname(__FILE__), "..", "lib"))
-$LOAD_PATH.unshift(lib_directory) unless $LOAD_PATH.include?(lib_directory)
+$LOAD_PATH.unshift(lib_directory) unless $LOAD_PATH.map { |directory| File.expand_path(directory) }.include?(lib_directory)
 
 require "frecon"
 

--- a/frecon.gemspec
+++ b/frecon.gemspec
@@ -1,5 +1,5 @@
 lib_directory = File.expand_path(File.join(File.dirname(__FILE__), "lib"))
-$LOAD_PATH.unshift(lib_directory) unless $LOAD_PATH.include?(lib_directory)
+$LOAD_PATH.unshift(lib_directory) unless $LOAD_PATH.map { |directory| File.expand_path(directory) }.include?(lib_directory)
 
 require "frecon/base/variables"
 


### PR DESCRIPTION
A small change, the downside is that this causes the initialization of the `bin/frecon` binary and the loading of `frecon.gemspec` to increase in time ever-so-slightly.  All paths are expanded now, which prevents some cases where a directory would get added to the `$LOAD_PATH` more than once.
