### PR TITLE
Remove database log messages.

### DIFF
--- a/lib/frecon/database.rb
+++ b/lib/frecon/database.rb
@@ -27,6 +27,14 @@ module FReCon
 			else
 				Mongoid.load!(File.join(File.dirname(__FILE__), "mongoid.yml"), environment)
 			end
+			
+			if environment == :development
+				Mongoid.logger.level = Logger::DEBUG
+				Mongoid.logger = Logger.new($stdout)
+
+				Moped.logger.level = Logger::DEBUG
+				Moped.logger = Logger.new($stdout)
+			end
 		end
 	end
 end


### PR DESCRIPTION
I find that they clutter the output.

It would be great if we could programmatically verify that something hit Mongoid and did stuff, but I'm not sure that it's the best to verify by checking the database logs.
