### PR TITLE
FReCon::Controller.update: Allow post_data override.

### DIFF
--- a/lib/frecon/controller.rb
+++ b/lib/frecon/controller.rb
@@ -62,10 +62,10 @@ module FReCon
 			end
 		end
 
-		def self.update(request, params)
+		def self.update(request, params, post_data = nil)
 			raise RequestError.new(400, "Must supply a #{model_name.downcase}!") unless params[:id]
 
-			post_data = process_request request
+			post_data ||= process_request request
 
 			@model = model.find params[:id]
 


### PR DESCRIPTION
This mirrors functionality in FReCon::Controller.create, meaning that the request is not processed if post_data is already present. This will make it easier to debug the methods and also to create test suite cases based on it.

Since `FReCon::Controller.delete`, `FReCon::Controller.show`, and `FReCon::Controller.index` all don't bother with the request body, we shouldn't need to deal with special cases (or at least I don't think so).

Look good, @Sammidysam?
