### PR TITLE
Remove support for IRB.

### DIFF
--- a/lib/frecon/console.rb
+++ b/lib/frecon/console.rb
@@ -15,23 +15,9 @@ module FReCon
 		def self.start
 			Database.setup(FReCon.environment)
 
-			# Use pry if it is installed.
-			# Use the context of the FReCon module;
-			# this allows for writing "Team" instead of "FReCon::Team".
-			begin
-				require "pry"
+			require "pry"
 
-				FReCon.pry
-			rescue LoadError
-				require "irb"
-
-				IRB.setup nil
-				IRB.conf[:MAIN_CONTEXT] = IRB::Irb.new.context
-
-				require "irb/ext/multi-irb"
-
-				IRB.irb nil, FReCon
-			end
+			FReCon.pry
 		end
 	end
 end


### PR DESCRIPTION
We no longer want to do this checking.  IRB isn't very testable, and since pry is listed as a dependency for this project, we shouldn't use IRB (since it likely hasn't been used at all anyways).  This pull request, when merged, should close #62.
