### PR TITLE
Require Mongoid prior to BSON monkey-patching

### DIFF
--- a/lib/frecon/base/bson.rb
+++ b/lib/frecon/base/bson.rb
@@ -7,6 +7,8 @@
 # license with this program.  If not, please see
 # <http://opensource.org/licenses/MIT>.
 
+require "mongoid"
+
 # Public: An extension for the BSON module.
 module BSON
 	# Public: A monkey-patch for the BSON::ObjectId class which introduces an


### PR DESCRIPTION
Previously, as mentioned in #87, there was a dependency on Mongoid being loaded for the monkey patch to be successful.  Otherwise, it would spit out the old value when it was called.  This resolves this.

*This PR connects to #87.*