### PR TITLE
gemspec: Add 'pry' as an explicit dependency

### DIFF
--- a/frecon.gemspec
+++ b/frecon.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |s|
 	s.executables << 'frecon'
 
 	s.add_runtime_dependency 'sinatra', ['~> 1.4']
+	s.add_runtime_dependency 'pry', ['~> 0.10']
 	s.add_runtime_dependency 'thin', ['~> 1.6']
 	s.add_runtime_dependency 'mongoid', ['~> 4.0']
 	s.add_runtime_dependency 'httparty', ['~> 0.13']


### PR DESCRIPTION
It was implied, but not present in new environments which don't have `pry` installed.  Silly mistake.  I will merge this if I don't hear back from @Sammidysam quickly.

This PR fixes #94.