### PR TITLE
frecon: Explicitly Require Dependencies

### DIFF
--- a/lib/frecon.rb
+++ b/lib/frecon.rb
@@ -7,22 +7,45 @@
 # license with this program.  If not, please see
 # <http://opensource.org/licenses/MIT>.
 
-require 'mongoid'
-
+require 'frecon/base/bson'
+require 'frecon/base/environment'
+require 'frecon/base/object'
+require 'frecon/base/variables'
 require 'frecon/base'
 
+require 'frecon/console'
+
 require 'frecon/controller'
+require 'frecon/controllers/competitions_controller'
+require 'frecon/controllers/dump_controller'
+require 'frecon/controllers/matches_controller'
+require 'frecon/controllers/participations_controller'
+require 'frecon/controllers/records_controller'
+require 'frecon/controllers/robots_controller'
+require 'frecon/controllers/teams_controller'
 require 'frecon/controllers'
+
+require 'frecon/database'
+require 'frecon/match_number'
+
 require 'frecon/model'
+require 'frecon/models/competition'
+require 'frecon/models/match'
+require 'frecon/models/participation'
+require 'frecon/models/record'
+require 'frecon/models/robot'
+require 'frecon/models/team'
 require 'frecon/models'
+
 require 'frecon/scraper'
 require 'frecon/scrapers'
 
-require 'frecon/match_number'
+require 'frecon/mongoid/criteria'
 require 'frecon/position'
 require 'frecon/request_error'
 require 'frecon/routes'
 
-require 'frecon/database'
+require 'frecon/scraper'
+require 'frecon/scrapers'
+
 require 'frecon/server'
-require 'frecon/console'

--- a/lib/frecon/base.rb
+++ b/lib/frecon/base.rb
@@ -8,6 +8,6 @@
 # <http://opensource.org/licenses/MIT>.
 
 require 'frecon/base/bson'
-require 'frecon/base/object'
 require 'frecon/base/environment'
+require 'frecon/base/object'
 require 'frecon/base/variables'

--- a/lib/frecon/console.rb
+++ b/lib/frecon/console.rb
@@ -7,9 +7,8 @@
 # license with this program.  If not, please see
 # <http://opensource.org/licenses/MIT>.
 
-require 'frecon/base/variables'
 require 'frecon/database'
-require 'frecon/server'
+require 'frecon'
 
 module FReCon
 	# Public: The wrapper system for a pry console.

--- a/lib/frecon/console.rb
+++ b/lib/frecon/console.rb
@@ -7,7 +7,6 @@
 # license with this program.  If not, please see
 # <http://opensource.org/licenses/MIT>.
 
-require 'frecon/database'
 require 'frecon'
 
 module FReCon

--- a/lib/frecon/controller.rb
+++ b/lib/frecon/controller.rb
@@ -9,6 +9,8 @@
 
 require 'json'
 
+require 'frecon/request_error'
+
 require 'frecon/base/bson'
 require 'frecon/base/object'
 

--- a/lib/frecon/controller.rb
+++ b/lib/frecon/controller.rb
@@ -7,10 +7,10 @@
 # license with this program.  If not, please see
 # <http://opensource.org/licenses/MIT>.
 
+require 'json'
+
 require 'frecon/base/bson'
-require 'frecon/base/environment'
 require 'frecon/base/object'
-require 'frecon/base/variables'
 
 module FReCon
 	# Public: A base class to represent a controller.

--- a/lib/frecon/controller.rb
+++ b/lib/frecon/controller.rb
@@ -7,7 +7,10 @@
 # license with this program.  If not, please see
 # <http://opensource.org/licenses/MIT>.
 
-require 'frecon/base'
+require 'frecon/base/bson'
+require 'frecon/base/environment'
+require 'frecon/base/object'
+require 'frecon/base/variables'
 
 module FReCon
 	# Public: A base class to represent a controller.

--- a/lib/frecon/controllers.rb
+++ b/lib/frecon/controllers.rb
@@ -7,11 +7,6 @@
 # license with this program.  If not, please see
 # <http://opensource.org/licenses/MIT>.
 
-require 'json'
-require 'frecon/request_error'
-
-require 'frecon/controller'
-
 require 'frecon/controllers/competitions_controller'
 require 'frecon/controllers/dump_controller'
 require 'frecon/controllers/matches_controller'

--- a/lib/frecon/controllers/competitions_controller.rb
+++ b/lib/frecon/controllers/competitions_controller.rb
@@ -7,8 +7,8 @@
 # license with this program.  If not, please see
 # <http://opensource.org/licenses/MIT>.
 
-require 'json'
 require 'frecon/models/competition'
+require 'frecon/controller'
 
 module FReCon
 	# Public: The Competitions controller.

--- a/lib/frecon/controllers/matches_controller.rb
+++ b/lib/frecon/controllers/matches_controller.rb
@@ -7,8 +7,8 @@
 # license with this program.  If not, please see
 # <http://opensource.org/licenses/MIT>.
 
-require 'json'
 require 'frecon/models/match'
+require 'frecon/controller'
 
 module FReCon
 	# Public: The Matches controller.

--- a/lib/frecon/controllers/participations_controller.rb
+++ b/lib/frecon/controllers/participations_controller.rb
@@ -7,8 +7,8 @@
 # license with this program.  If not, please see
 # <http://opensource.org/licenses/MIT>.
 
-require 'json'
 require 'frecon/models/participation'
+require 'frecon/controller'
 
 module FReCon
 	# Public: The Participations controller.

--- a/lib/frecon/controllers/records_controller.rb
+++ b/lib/frecon/controllers/records_controller.rb
@@ -7,8 +7,8 @@
 # license with this program.  If not, please see
 # <http://opensource.org/licenses/MIT>.
 
-require 'json'
 require 'frecon/models/record'
+require 'frecon/controller'
 
 module FReCon
 	# Public: The Records controller.

--- a/lib/frecon/controllers/robots_controller.rb
+++ b/lib/frecon/controllers/robots_controller.rb
@@ -7,8 +7,8 @@
 # license with this program.  If not, please see
 # <http://opensource.org/licenses/MIT>.
 
-require 'json'
 require 'frecon/models/robot'
+require 'frecon/controller'
 
 module FReCon
 	# Public: The Robots controller.

--- a/lib/frecon/controllers/teams_controller.rb
+++ b/lib/frecon/controllers/teams_controller.rb
@@ -7,8 +7,8 @@
 # license with this program.  If not, please see
 # <http://opensource.org/licenses/MIT>.
 
-require 'json'
 require 'frecon/models/team'
+require 'frecon/controller'
 
 module FReCon
 	# Public: The Teams controller.

--- a/lib/frecon/database.rb
+++ b/lib/frecon/database.rb
@@ -8,15 +8,13 @@
 # <http://opensource.org/licenses/MIT>.
 
 require 'logger'
-
-require 'frecon/base/variables'
-
 require 'mongoid'
-require 'frecon/mongoid/criteria'
-
 require 'tempfile'
 require 'yaml'
 
+require 'frecon/base/bson'
+require 'frecon/mongoid/criteria'
+require 'frecon/base/variables'
 require 'frecon/models'
 
 module FReCon

--- a/lib/frecon/match_number.rb
+++ b/lib/frecon/match_number.rb
@@ -7,7 +7,10 @@
 # license with this program.  If not, please see
 # <http://opensource.org/licenses/MIT>.
 
-require 'frecon/base'
+require 'frecon/base/bson'
+require 'frecon/base/environment'
+require 'frecon/base/object'
+require 'frecon/base/variables'
 
 module FReCon
 	# Public: A wrapper to handle converting match numbers and storing them.

--- a/lib/frecon/model.rb
+++ b/lib/frecon/model.rb
@@ -9,6 +9,7 @@
 
 require 'mongoid'
 require 'frecon/mongoid/criteria'
+require 'frecon/base/bson'
 
 module FReCon
 	# Public: A base class designed to assist with creating MongoDB Models

--- a/lib/frecon/position.rb
+++ b/lib/frecon/position.rb
@@ -7,7 +7,10 @@
 # license with this program.  If not, please see
 # <http://opensource.org/licenses/MIT>.
 
-require 'frecon/base'
+require 'frecon/base/bson'
+require 'frecon/base/environment'
+require 'frecon/base/object'
+require 'frecon/base/variables'
 
 module FReCon
 	# Public: A wrapper to handle converting team positions and storing them.

--- a/lib/frecon/server.rb
+++ b/lib/frecon/server.rb
@@ -12,7 +12,6 @@ require 'sinatra/base'
 require 'frecon/base/variables'
 require 'frecon/database'
 require 'frecon/routes'
-require 'frecon/controllers'
 
 module FReCon
 	# Public: The Sinatra web server.


### PR DESCRIPTION
Instead of trying to use centralized requires, (i.e. requiring files and expecting them to require other files so that we can use the contents of those files they're requiring) it is a better idea to explicitly name what we want to require.

This paradigm suggests the following course of action:
* For each file, ensure that only the dependencies required to make that file functional are present.
* Make `lib/frecon.rb` require all files, recursively, in `lib/frecon/`.
* For hub files, alphabetically list each file that should be required. (The later use of these hub files is okay as long as they alphabetically require their dependencies.)

This PR contains the beginning work on this.  Extensive testing should take place to make sure that dependencies aren't broken, as they likely will be.