### PR TITLE
Add Initial EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[{*.rb,Gemfile,Guardfile,Rakefile,bin/frecon}]
+# indent_style = space
+# indent_size = 2
+indent_style = tab


### PR DESCRIPTION
I think that the EditorConfig introduced by ed8137e7cd576367f2916c31e37716f5ca8b7815 is a good enough baseline to add to master.  I am definitely willing to accept PR's and feedback on it and get it set.

For my fellow Emacs users, I have done some relevant work in [rye/duff](https://github.com/rye/duff) regarding EditorConfig and smart-tabs-mode.  Smart tabs is still the format to use.  We will request the correction of any pull requests which submit with hard tabs, but beyond that all should be well.