### PR TITLE
Hotfix Travis Configuration, Use Ruby 2.2.5 (stable) and Ruby 2.3.1 (stable)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 language: ruby
 rvm:
   - 2.2.5
+  - 2.3.1
 
 install:
   - script/setup

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 
 language: ruby
 rvm:
-  - 2.2.3
+  - 2.2.5
 
 install:
   - script/setup


### PR DESCRIPTION
This is not much of a functional change, but we should consider listing dependencies/defining a required Ruby version so as to prevent upstream dependency hell with `listen` again.