### PR TITLE
Merge v1.5.0 Branch to Switch to New Scheme

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,0 @@
-service_name: travis-ci

--- a/.simplecov
+++ b/.simplecov
@@ -1,9 +1,0 @@
-# -*- mode: ruby -*-
-
-require 'simplecov'
-require 'coveralls'
-
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([SimpleCov::Formatter::HTMLFormatter, Coveralls::SimpleCov::Formatter])
-SimpleCov.start do
-	add_filter '.bundle/'
-end

--- a/frecon.gemspec
+++ b/frecon.gemspec
@@ -47,7 +47,6 @@ Gem::Specification.new do |s|
 	s.add_development_dependency 'guard', ['~> 2.14']
 	s.add_development_dependency 'guard-rspec', ['~> 4.7']
 
-	s.add_development_dependency 'coveralls', ['~> 0.8']
 	s.add_development_dependency 'codeclimate', ['~> 0.35']
 	s.add_development_dependency 'codeclimate-test-reporter', ['~> 0.6']
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,13 @@
 require 'rspec'
 
-# Initialization code for Coveralls.io
-require 'coveralls'
-Coveralls.wear!
-
 # Initialization code for CodeClimate
 require 'codeclimate-test-reporter'
 CodeClimate::TestReporter.start
+
+# Set up SimpleCov
+SimpleCov.start do
+	formatter SimpleCov::Formatter::MultiFormatter.new([
+		SimpleCov::Formatter::HTMLFormatter,
+		CodeClimate::TestReporter::Formatter
+	])
+end


### PR DESCRIPTION
I've been toying around with versioning schemes, and I've decided that the `master` branch should really not just be a place to merge new versions.  `master`, itself, should be the *latest development/deployable version*, not anything else.

The problem, of course, lies in our definition of *deployability*.  If we speak simply of deploying by uploading to RubyGems, then technically the versioning system I switched to works; creating a version branch and using that as the base for each release makes sense, then merging that branch and releasing on the merge commit.

It's much better to do otherwise, however, by simply merging feature/fix branches into `master` as they come along, versioning appropriately.  And that is how it will go.