### PR TITLE
Separate VERSION and ENVIRONMENT from Variables

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,2 @@
 --color
---format documentation
 --require spec_helper

--- a/lib/frecon/base/environment.rb
+++ b/lib/frecon/base/environment.rb
@@ -170,4 +170,7 @@ module FReCon
 
 	end
 
+	# Public: An Environment representing the system execution environment.
+	ENVIRONMENT = Environment.new(:development)
+
 end

--- a/lib/frecon/base/variables.rb
+++ b/lib/frecon/base/variables.rb
@@ -15,7 +15,4 @@ module FReCon
 	# Public: A String representing the current version of FReCon.
 	VERSION = '1.4.0'
 
-	# Public: An Environment representing the system execution environment.
-	ENVIRONMENT = Environment.new(:development)
-
 end

--- a/lib/frecon/base/variables.rb
+++ b/lib/frecon/base/variables.rb
@@ -8,11 +8,4 @@
 # <http://opensource.org/licenses/MIT>.
 
 require 'frecon/base/environment'
-
-# Public: The FReCon API module.
-module FReCon
-
-	# Public: A String representing the current version of FReCon.
-	VERSION = '1.4.0'
-
-end
+require 'frecon/base/version'

--- a/lib/frecon/base/version.rb
+++ b/lib/frecon/base/version.rb
@@ -10,9 +10,36 @@
 # Public: The FReCon API module.
 module FReCon
 
-	class Version < String; end
+	class Version
+		attr_reader :major, :minor, :patch, :prerelease
+
+		def initialize(major:, minor:, patch:, prerelease: nil)
+			@major, @minor, @patch, @prerelease = major, minor, patch, prerelease
+		end
+
+		def to_s
+			format_string % [@major, @minor, @patch, @prerelease]
+		end
+
+		def prerelease?
+			!!@prerelease
+		end
+
+		def release?
+			!@prerelease
+		end
+
+		protected
+
+		PRERELEASE_FORMAT_STRING = '%d.%d.%d-%s'
+		RELEASE_FORMAT_STRING = '%d.%d.%d'
+
+		def format_string
+			prerelease? ? PRERELEASE_FORMAT_STRING : RELEASE_FORMAT_STRING
+		end
+	end
 
 	# Public: A String representing the current version of FReCon.
-	VERSION = Version.new('1.4.0')
+	VERSION = Version.new(major: 1, minor: 4, patch: 0)
 
 end

--- a/lib/frecon/base/version.rb
+++ b/lib/frecon/base/version.rb
@@ -39,7 +39,7 @@ module FReCon
 		end
 	end
 
-	# Public: A String representing the current version of FReCon.
-	VERSION = Version.new(major: 1, minor: 4, patch: 0)
+	# Public: A Version representing the current version of FReCon.
+	VERSION = Version.new(major: 1, minor: 5, patch: 0)
 
 end

--- a/lib/frecon/base/version.rb
+++ b/lib/frecon/base/version.rb
@@ -1,0 +1,16 @@
+# lib/frecon/base/version.rb
+#
+# Copyright (C) 2016 Christopher Cooper, Sam Craig, Tiger Huang, Vincent Mai, Sam Mercier, and Kristofer Rye
+#
+# This file is part of FReCon, an API for scouting at FRC Competitions, which is
+# licensed under the MIT license.  You should have received a copy of the MIT
+# license with this program.  If not, please see
+# <http://opensource.org/licenses/MIT>.
+
+# Public: The FReCon API module.
+module FReCon
+
+	# Public: A String representing the current version of FReCon.
+	VERSION = '1.4.0'
+
+end

--- a/lib/frecon/base/version.rb
+++ b/lib/frecon/base/version.rb
@@ -39,7 +39,7 @@ module FReCon
 		end
 	end
 
-	# Public: A Version representing the current version of FReCon.
-	VERSION = Version.new(major: 1, minor: 5, patch: 0)
+	# Public: A String representing the current version of FReCon.
+	VERSION = Version.new(major: 1, minor: 4, patch: 0)
 
 end

--- a/lib/frecon/base/version.rb
+++ b/lib/frecon/base/version.rb
@@ -10,7 +10,9 @@
 # Public: The FReCon API module.
 module FReCon
 
+	class Version < String; end
+
 	# Public: A String representing the current version of FReCon.
-	VERSION = '1.4.0'
+	VERSION = Version.new('1.4.0')
 
 end

--- a/spec/lib/frecon/base/environment_spec.rb
+++ b/spec/lib/frecon/base/environment_spec.rb
@@ -2,8 +2,9 @@ require 'spec_helper'
 
 require 'securerandom'
 
-describe FReCon::Environment do
+require 'frecon/base/environment'
 
+describe FReCon::Environment do
 	subject do
 		FReCon::Environment.new(:development)
 	end
@@ -20,6 +21,7 @@ describe FReCon::Environment do
 
 			allow(subject).to receive(:validate_symbol)
 			expect(subject).to receive(:validate_symbol).with(symbol)
+
 			subject.variable = symbol
 		end
 
@@ -72,4 +74,14 @@ describe FReCon::Environment do
 
 	describe '#system_configuration_filename'
 	describe '#user_configuration_filename'
+end
+
+describe FReCon do
+	it 'has an environment' do
+		expect(FReCon.const_get(:ENVIRONMENT)).to_not be_nil
+	end
+
+	it 'has an environment which is a FReCon::Environment' do
+		expect(FReCon.const_get(:ENVIRONMENT)).to be_a FReCon::Environment
+	end
 end

--- a/spec/lib/frecon/base/variables_spec.rb
+++ b/spec/lib/frecon/base/variables_spec.rb
@@ -1,13 +1,14 @@
 require 'spec_helper'
 
+require 'frecon/base/variables'
+
 describe FReCon do
 	it 'has a version' do
- 		expect(FReCon.const_get(:VERSION)).to_not be_nil
- 		expect(FReCon.const_get(:VERSION)).to be_a String
+		expect(FReCon.const_get(:VERSION)).to_not be_nil
+		expect(FReCon.const_get(:VERSION)).to be_a FReCon::Version
 	end
 
 	it 'has an environment' do
  		expect(FReCon.const_get(:ENVIRONMENT)).to_not be_nil
- 		expect(FReCon.const_get(:ENVIRONMENT)).to be_a FReCon::Environment
 	end
 end

--- a/spec/lib/frecon/base/variables_spec.rb
+++ b/spec/lib/frecon/base/variables_spec.rb
@@ -5,7 +5,6 @@ require 'frecon/base/variables'
 describe FReCon do
 	it 'has a version' do
 		expect(FReCon.const_get(:VERSION)).to_not be_nil
-		expect(FReCon.const_get(:VERSION)).to be_a FReCon::Version
 	end
 
 	it 'has an environment' do

--- a/spec/lib/frecon/base/version_spec.rb
+++ b/spec/lib/frecon/base/version_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+require 'frecon/base/version'
+
+describe FReCon do
+	it 'has a version' do
+		expect(FReCon.const_get(:VERSION)).to_not be_nil
+	end
+
+	it 'has a version which is a FReCon::Version' do
+		expect(FReCon.const_get(:VERSION)).to be_a FReCon::Version
+	end
+end

--- a/spec/lib/frecon/base/version_spec.rb
+++ b/spec/lib/frecon/base/version_spec.rb
@@ -2,6 +2,40 @@ require 'spec_helper'
 
 require 'frecon/base/version'
 
+describe FReCon::Version do
+	context 'when representing non-prerelease versions' do
+		subject do
+			FReCon::Version.new(major: rand(8), minor: rand(8), patch: rand(8))
+		end
+
+		it 'produces a version which is RubyGems-compliant' do
+			require 'rubygems/version'
+
+			# Manually verify that the string matches the version pattern internally
+			# used for checking by RubyGems.
+			expect(subject.to_s).to match(Gem::Version::ANCHORED_VERSION_PATTERN)
+
+			# Use the RubyGems validator to manually verify correctness.
+			expect(Gem::Version.correct?(subject.to_s)).not_to be(nil)
+
+			# Try to create a RubyGems Version out
+			# of the string that Gem::Version generates.
+			#
+			# This ensures feature-completeness within
+			# RubyGems itself.
+			expect do
+				Gem::Version.new(subject.to_s)
+			end.not_to raise_error
+		end
+	end
+
+	context 'when representing prerelease versions' do
+		subject do
+			FReCon::Version.new(major: rand(8), minor: rand(8), patch: rand(8), prerelease: 'alpha0')
+		end
+	end
+end
+
 describe FReCon do
 	it 'has a version' do
 		expect(FReCon.const_get(:VERSION)).to_not be_nil


### PR DESCRIPTION
In the interest of keeping things interesting and making things a bit more semantic, I've extracted the VERSION and ENVIRONMENT constants from the `lib/frecon/base/variables.rb` file into their own files. (`lib/frecon/base/{environment,version}.rb`)

This will allow things to be tested more thoroughly.  Of course, this isn't a very pointed change, but I figure it's good to keep moving, and I want to get rid of this branch.